### PR TITLE
[VTP-2016] Null check in case we didn't actually migrate anything

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-migrations-action",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "JavaScript Action for Contentful migrations",
   "main": "src/index.ts",
   "scripts": {

--- a/src/action/applyMigrations.ts
+++ b/src/action/applyMigrations.ts
@@ -75,9 +75,11 @@ export default async function ({ environment, defaultLocale }: { environment: En
     Logger.success(`Migration script ${migrationToRun}.js succeeded`);
   }
 
-  storedVersionEntry.fields.version[defaultLocale] = lastMigration;
-  const updatedVersionEntry = await storedVersionEntry.update();
-  await updatedVersionEntry.publish();
+  if (lastMigration) {
+    storedVersionEntry.fields.version[defaultLocale] = lastMigration;
+    const updatedVersionEntry = await storedVersionEntry.update();
+    await updatedVersionEntry.publish();
+  }
 
   Logger.success(`Updated field ${VERSION_FIELD} in ${VERSION_CONTENT_TYPE} entry to ${migrationToRun}`);
   /* eslint-enable no-await-in-loop */


### PR DESCRIPTION
This resolves an issue if we don't find any migrations to run. Prevents us from trying to write undefined as version number.