### PR TITLE
[SAZ-363] contentful-action Logging Error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,16 +23,32 @@ const sanitizeMsg = (message: string): string => message.replace(/\n|\r/g, '');
 /* eslint-disable no-console */
 export const Logger = {
   log(message) {
-    console.log(sanitizeMsg(message));
+    if (typeof message === 'string') {
+      console.log(sanitizeMsg(message));
+    } else {
+      console.log(message);
+    }
   },
   info(message) {
-    console.info(sanitizeMsg(message));
+    if (typeof message === 'string') {
+      console.info(sanitizeMsg(message));
+    } else {
+      console.info(message);
+    }
   },
   success(message) {
-    console.info(sanitizeMsg(message));
+    if (typeof message === 'string') {
+      console.info(sanitizeMsg(message));
+    } else {
+      console.info(message);
+    }
   },
   warn(message) {
-    console.warn(sanitizeMsg(message));
+    if (typeof message === 'string') {
+      console.warn(sanitizeMsg(message));
+    } else {
+      console.warn(message);
+    }
   },
   error(message) {
     if (typeof message === 'string') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,11 +35,19 @@ export const Logger = {
     console.warn(sanitizeMsg(message));
   },
   error(message) {
-    typeof message === 'string' ? console.error(sanitizeMsg(message)) : console.error(message);
+    if (typeof typeof message === 'string') {
+      console.error(sanitizeMsg(message));
+    } else {
+      console.error(message);
+    }
   },
   verbose(message) {
     if (LOG_LEVEL === 'verbose') {
-      typeof message === 'string' ? console.debug(sanitizeMsg(message)) : console.debug(message);
+      if (typeof typeof message === 'string') {
+        console.debug(sanitizeMsg(message));
+      } else {
+        console.debug(message);
+      }
     }
   },
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,7 @@ export const Logger = {
     console.warn(sanitizeMsg(message));
   },
   error(message) {
-    if (typeof typeof message === 'string') {
+    if (typeof message === 'string') {
       console.error(sanitizeMsg(message));
     } else {
       console.error(message);
@@ -43,7 +43,7 @@ export const Logger = {
   },
   verbose(message) {
     if (LOG_LEVEL === 'verbose') {
-      if (typeof typeof message === 'string') {
+      if (typeof message === 'string') {
         console.debug(sanitizeMsg(message));
       } else {
         console.debug(message);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,7 @@ export const Logger = {
     console.warn(sanitizeMsg(message));
   },
   error(message) {
-    console.error(sanitizeMsg(message));
+    typeof message === 'string' ? console.error(sanitizeMsg(message)) : console.error(message);
   },
   verbose(message) {
     if (LOG_LEVEL === 'verbose') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,7 @@ export const Logger = {
   },
   verbose(message) {
     if (LOG_LEVEL === 'verbose') {
-      console.debug(sanitizeMsg(message));
+      typeof message === 'string' ? console.debug(sanitizeMsg(message)) : console.debug(message);
     }
   },
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,52 +18,28 @@ chalk.level = 3;
 
 const stringifyObject = (object) => JSON.stringify(object, null, 2);
 
-const sanitizeMsg = (message: string): string => message.replace(/\n|\r/g, '');
+const sanitizeMsg = (message): string => String(message).replace(/\n|\r/g, '');
 
 /* eslint-disable no-console */
 export const Logger = {
   log(message) {
-    if (typeof message === 'string') {
-      console.log(sanitizeMsg(message));
-    } else {
-      console.log(message);
-    }
+    console.log(sanitizeMsg(message));
   },
   info(message) {
-    if (typeof message === 'string') {
-      console.info(sanitizeMsg(message));
-    } else {
-      console.info(message);
-    }
+    console.info(sanitizeMsg(message));
   },
   success(message) {
-    if (typeof message === 'string') {
-      console.info(sanitizeMsg(message));
-    } else {
-      console.info(message);
-    }
+    console.info(sanitizeMsg(message));
   },
   warn(message) {
-    if (typeof message === 'string') {
-      console.warn(sanitizeMsg(message));
-    } else {
-      console.warn(message);
-    }
+    console.warn(sanitizeMsg(message));
   },
   error(message) {
-    if (typeof message === 'string') {
-      console.error(sanitizeMsg(message));
-    } else {
-      console.error(message);
-    }
+    console.error(sanitizeMsg(message));
   },
   verbose(message) {
     if (LOG_LEVEL === 'verbose') {
-      if (typeof message === 'string') {
-        console.debug(sanitizeMsg(message));
-      } else {
-        console.debug(message);
-      }
+      console.debug(sanitizeMsg(message));
     }
   },
 };


### PR DESCRIPTION
[SAZ-363](https://infatuation.atlassian.net/browse/SAZ-363)

---

<img width="841" alt="image" src="https://github.com/user-attachments/assets/33a440c4-031b-4f01-aea1-f93489e554e2">

---

`Logger.error(...)` and `Logger.verbose(...)` may not be strings and the `sanitizeMsg(...)` function requires the input to be a string to work properly. To fix, type checking was added to the `message` input.

[SAZ-363]: https://infatuation.atlassian.net/browse/SAZ-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ