### PR TITLE
[SAZ-369] Contentful Action is adding env to Engineering role multiple times

### DIFF
--- a/src/action/updateRoleEnvironmentAccess.ts
+++ b/src/action/updateRoleEnvironmentAccess.ts
@@ -1,5 +1,5 @@
 import type { Environment, Space } from 'contentful-management';
-import { createAllowPolicyForEnvironment } from '../role';
+import { containsEnvironmentId, createAllowPolicyForEnvironment } from '../role';
 import { INPUT_UPDATE_ENVIRONMENT_ACCESS_ROLE_ID } from '../constants';
 import { Logger } from '../utils';
 
@@ -11,7 +11,7 @@ export default async function ({ space, environment }: { space: Space; environme
 
     let isEnvironmentIdInRolePolicy = false;
     for (const policy of role.policies) {
-      if (environment.sys.id === policy.constraint.and[1].equals[1]) {
+      if (policy.effect === 'allow' && containsEnvironmentId(policy.constraint, environment.sys.id)) {
         isEnvironmentIdInRolePolicy = true;
       }
     }

--- a/src/action/updateRoleEnvironmentAccess.ts
+++ b/src/action/updateRoleEnvironmentAccess.ts
@@ -11,7 +11,13 @@ export default async function ({ space, environment }: { space: Space; environme
 
     let isEnvironmentIdInRolePolicy = false;
     for (const policy of role.policies) {
-      if (policy.effect === 'allow' && containsEnvironmentId(policy.constraint, environment.sys.id)) {
+      if (
+        policy.effect === 'allow' &&
+        Array.isArray(policy.actions) &&
+        // @ts-expect-error 'access' is a valid value when an Env is assigned via UI
+        policy.actions.includes('access') &&
+        containsEnvironmentId(policy.constraint, environment.sys.id)
+      ) {
         isEnvironmentIdInRolePolicy = true;
       }
     }

--- a/src/action/updateRoleEnvironmentAccess.ts
+++ b/src/action/updateRoleEnvironmentAccess.ts
@@ -16,9 +16,13 @@ export default async function ({ space, environment }: { space: Space; environme
       }
     }
 
-    if (!isEnvironmentIdInRolePolicy) role.policies.push(createAllowPolicyForEnvironment(environment.sys.id));
-    await role.update();
-    Logger.success(`Successfully updated the Role ${roleId} with Environment ${environment.sys.id}.`);
+    if (!isEnvironmentIdInRolePolicy) {
+      role.policies.push(createAllowPolicyForEnvironment(environment.sys.id));
+      await role.update();
+      Logger.success(`Successfully updated the Role ${roleId} with Environment ${environment.sys.id}.`);
+    } else {
+      Logger.log(`The Role ${roleId} has already been given access to Environment ${environment.sys.id}.`);
+    }
   } catch (error) {
     Logger.error(`Failed to update the Role ${roleId} with Environment ${environment.sys.id}.`);
     Logger.verbose(error);

--- a/src/action/updateRoleEnvironmentAccess.ts
+++ b/src/action/updateRoleEnvironmentAccess.ts
@@ -13,7 +13,8 @@ export default async function ({ space, environment }: { space: Space; environme
     );
     if (isEnvironmentIdInRolePolicy) {
       Logger.log(`The Role ${roleId} has already been given access to Environment ${environment.sys.id}.`);
-      return; // eslint-disable-line padding-line-between-statements
+
+      return;
     }
     role.policies.push(createAllowPolicyForEnvironment(environment.sys.id));
     await role.update();

--- a/src/action/updateRoleEnvironmentAccess.ts
+++ b/src/action/updateRoleEnvironmentAccess.ts
@@ -8,7 +8,15 @@ export default async function ({ space, environment }: { space: Space; environme
   try {
     Logger.log(`Updating the Role ${roleId} to have access on Environment: ${environment.sys.id}.`);
     const role = await space.getRole(roleId);
-    role.policies.push(createAllowPolicyForEnvironment(environment.sys.id));
+
+    let isEnvironmentIdInRolePolicy = false;
+    for (const policy of role.policies) {
+      if (environment.sys.id === policy.constraint.and[1].equals[1]) {
+        isEnvironmentIdInRolePolicy = true;
+      }
+    }
+
+    if (!isEnvironmentIdInRolePolicy) role.policies.push(createAllowPolicyForEnvironment(environment.sys.id));
     await role.update();
     Logger.success(`Successfully updated the Role ${roleId} with Environment ${environment.sys.id}.`);
   } catch (error) {

--- a/src/action/updateRoleEnvironmentAccess.ts
+++ b/src/action/updateRoleEnvironmentAccess.ts
@@ -13,11 +13,11 @@ export default async function ({ space, environment }: { space: Space; environme
     );
     if (isEnvironmentIdInRolePolicy) {
       Logger.log(`The Role ${roleId} has already been given access to Environment ${environment.sys.id}.`);
-    } else {
-      role.policies.push(createAllowPolicyForEnvironment(environment.sys.id));
-      await role.update();
-      Logger.success(`Successfully updated the Role ${roleId} with Environment ${environment.sys.id}.`);
+      return; // eslint-disable-line padding-line-between-statements
     }
+    role.policies.push(createAllowPolicyForEnvironment(environment.sys.id));
+    await role.update();
+    Logger.success(`Successfully updated the Role ${roleId} with Environment ${environment.sys.id}.`);
   } catch (error) {
     Logger.error(`Failed to update the Role ${roleId} with Environment ${environment.sys.id}.`);
     Logger.verbose(error);


### PR DESCRIPTION
[SAZ-369](https://infatuation.atlassian.net/browse/SAZ-369)

Updates action/updateRoleEnvironmentAccess to first check if the environment id exists in the Role's policies. 
If it does, log the reason why it was not added.
If it does not, proceed with adding the environment id to the Role's policies.

[SAZ-369]: https://infatuation.atlassian.net/browse/SAZ-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ